### PR TITLE
Add support for butler

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,13 @@ A packaging tool for [löve](https://love2d.org) games
 * Proper handling of shared libraries (both Lua modules and FFI)!
 * Packaging of those binaries in archives, including extra files
 * Versioned builds
+* Publish to [itch.io](https://itch.io) via butler
 * Control and customization along the way:
     - Configure which targets to build
     - Which files to include in the .love with a list of include/exclude patterns
     - Which löve binaries or AppImage to use as the base
     - Which artifacts to generate or keep
-    - pre- and postbuild hooks that are able to change the configuration on the fly. For example you can decide dynamically which files to include in the .love (e.g. through parsing asset lists), inject build metadata or just to upload your build automatically afterwards (e.g. via butler to [itch.io](https://itch.io)))
+    - pre- and postbuild hooks that are able to change the configuration on the fly. For example, you can decide dynamically which files to include in the .love (e.g. through parsing asset lists), inject build metadata, or just to upload your build automatically afterwards (e.g. via [steamcmd](https://partner.steamgames.com/doc/sdk/uploading) to Steam)
 
 ## Quickstart
 

--- a/makelove/butler.py
+++ b/makelove/butler.py
@@ -1,0 +1,25 @@
+#! /usr/bin/env python
+
+import os
+import subprocess
+import sys
+
+def publish(itchapp, config, version, targets, build_directory):
+    if config.get("publish_love", False):
+        targets = targets.copy()
+        targets += ['love']
+    for platform_target in targets:
+        target_root = os.path.join(build_directory, platform_target)
+        for file in os.listdir(target_root):
+            fpath = os.path.join(target_root, file)
+            if not os.path.isfile(fpath):
+                continue
+            
+            cmd = "butler push {fpath} {itchapp}:{platform_target} --userversion {version}".format(
+                fpath = fpath,
+                version = version,
+                itchapp = itchapp,
+                platform_target = platform_target
+            )
+            subprocess.check_call(cmd.split(' '))
+

--- a/makelove/config.py
+++ b/makelove/config.py
@@ -57,6 +57,12 @@ config_params = {
             "parameters": val.Dict(val.Any(), val.Any()),
         }
     ),
+    "butler": val.Section(
+        {
+            "itchapp": val.UserProjectPair(),
+            "publish_love": val.Bool(),
+        }
+    ),
     "windows": val.Section(
         {
             "exe_metadata": val.Dict(val.String(), val.String()),

--- a/makelove/validators.py
+++ b/makelove/validators.py
@@ -89,6 +89,18 @@ class Command(object):
         return "Command"
 
 
+class UserProjectPair(object):
+    def validate(self, obj):
+        if not isinstance(obj, str):
+            raise ValueError
+        if '/' not in obj:
+            raise ValueError
+        return obj
+
+    def description(self):
+        return "A username and project name separated by a slash (username/gamename)."
+
+
 class List(object):
     def __init__(self, value_validator):
         self.value_validator = value_validator

--- a/makelove_full.toml
+++ b/makelove_full.toml
@@ -66,13 +66,25 @@ prebuild = [
 ]
 postbuild = [
 	# {build_directory} and {version} will be replaced
-	# This is obviously only for illustrative purposes, you will probaly want to wrap this in a script
-	"butler push {build_directory}/win32/SuperGame-win32.zip pfirsich/supergame:win32 --userversion {version}",
+	# Assuming you have a publish_build script:
+	"publish_build --buildversion {version} --directory {build_directory}/win32/SuperGame-win32.zip",
 ]
 
 [hooks.parameters]
 # This section will not be checked when the config is validated and may contain
 # anything. It is intended as a place for configuration for your hooks.
+
+[butler]
+# Automatically push built targets to itch.io after builds.
+# Requires butler installed and in your PATH. See https://itch.io/docs/butler/
+#
+# For lovejs builds, "Kind of project" must be set to "HTML" on itch.io. After
+# your first upload, set your lovejs build to be played in the browser.
+itchapp = "pfirsich/supergame"
+
+# Additionally publish the .love file. Great for Linux users or people having
+# problems with the love binaries.
+publish_love = true
 
 [windows]
 # This is the same as archive_files at the top level, but will be added to the archive additionally


### PR DESCRIPTION
Make it trivial to use makelove to push butler builds to itch.io.

Adds a new butler section with two parameters:

itchapp - the name of the app: username/projectname.
publish_love - whether to publish the .love file (since it's not a
    target).

Remove butler from postbuild examples since we have a better way of
doing that.

Test
====

Created a test project on itch and pushed win32, win64, macos, lovejs,
love builds to it from Win10. Incremented version and pushed a new win32
build. Version numbers show as expected.

Play lovejs build in browser. Play from itch app.

Butler is not invoked when itchapp is not defined.