### PR TITLE
Pass current environ to hooks

### DIFF
--- a/makelove/hooks.py
+++ b/makelove/hooks.py
@@ -17,12 +17,13 @@ def execute_hook(command, config, version, targets, build_directory):
     with open(tmp_config_path, "w") as f:
         toml.dump(config, f)
 
-    env = {
+    env = os.environ.copy()
+    env.update({
         "MAKELOVE_TEMP_CONFIG": tmp_config_path,
         "MAKELOVE_VERSION": version or "",
         "MAKELOVE_TARGETS": ",".join(targets),
         "MAKELOVE_BUILD_DIRECTORY": build_directory,
-    }
+    })
 
     command_replaced = command.format(
         version=version or "", build_directory=build_directory


### PR DESCRIPTION
Fix `Fatal Python error: _Py_HashRandomization_Init` when using python
in hooks on Windows.

Allow invoking python and other commands that need a nonsparse
environment. Now you don't need to specify absolute paths to each
command in your hooks.

Instead of creating a blank environment and passing only a few
variables, use the current environ and add our variables. This allows
hooks to use executables from the PATH, rely on [SYSTEMROOT], etc.

Test
====

Used this config on Win10 and now my python can actually run.

    [hooks]
    prebuild = [
        "python3 makeprod.py --to-prod",
    ]
    postbuild = [
        "python3 makeprod.py --to-dev",
    ]

[SYSTEMROOT]: https://stackoverflow.com/questions/58997105/fatal-python-error-failed-to-get-random-numbers-to-initialize-python

PS: Thanks for making such a great packaging tool!