### PR TITLE
Add `license` parameter to `makelove.toml` (Closes #33)

### DIFF
--- a/makelove/config.py
+++ b/makelove/config.py
@@ -47,6 +47,7 @@ config_params = {
     "love_version": val.Choice(*all_love_versions),
     "default_targets": val.List(val.Choice(*all_targets)),
     "build_directory": val.Path(),
+    "license": val.Path(),
     "icon_file": val.Path(),
     "love_files": val.List(val.Path()),
     "keep_game_directory": val.Bool(),

--- a/makelove/macos.py
+++ b/makelove/macos.py
@@ -205,6 +205,9 @@ def build_macos(config, version, target, target_directory, love_file_path):
                     zipinfo.filename, get_info_plist_content(config, version)
                 )
                 continue
+            elif orig_filename == "love.app/Contents/Resources/license.txt" and "license" in config:
+                with open(config["license"], "r") as license_file:
+                    content = license_file.read()
             else:
                 content = love_binary_zip.read(orig_filename)
 

--- a/makelove/windows.py
+++ b/makelove/windows.py
@@ -223,7 +223,11 @@ def build_windows(config, version, target, target_directory, love_file_path):
                 fused.write(loveExe.read())
                 fused.write(loveZip.read())
 
-    copy("license.txt")
+    if "license" in config:
+        shutil.copyfile(config["license"], dest("license.txt"))
+    else:
+        copy("license.txt")
+    
     for f in os.listdir(love_binaries):
         if f.endswith(".dll"):
             copy(f)

--- a/makelove_full.toml
+++ b/makelove_full.toml
@@ -39,6 +39,10 @@ default_targets = ["win32", "win64", "appimage", "lovejs", "macos"] # <- possibl
 # By default this is "makelove-build"
 build_directory = "bauwerke"
 
+# If specified, love's license file will be replaced by the one specified.
+# Only applies to windows and macos builds.
+license = "license.txt"
+
 # This icon file will be used for the executables and the appimage.
 # The executable requires an .ico or a file that can be read by Pillow (Python library).
 # The appimage requires a .png, an .svg or anything Pillow can load.


### PR DESCRIPTION
This PR adds a `license` parameter to the configuration that overwrites love's `license.txt` with the specified one.
(Only works with windows and macos as appimage and lovejs don't include the license.)