### PR TITLE
Add `macos.archive_files`

### DIFF
--- a/makelove/config.py
+++ b/makelove/config.py
@@ -93,6 +93,7 @@ config_params = {
             "love_binaries": val.Path(),
             "icon_file": val.Path(),
             "app_metadata": val.Dict(val.String(), val.String()),
+            "archive_files": val.Dict(val.Path(), val.Path()),
         }
     ),
     "lovejs": val.Section(

--- a/makelove/macos.py
+++ b/makelove/macos.py
@@ -183,23 +183,23 @@ def build_macos(config, version, target, target_directory, love_file_path):
             archive_files.update(config["macos"]["archive_files"])
         
         written_files = set()
-        for k, v in archive_files.items():
-            path = f"{config['name']}.app/Contents/Resources/{v}"
-            if os.path.isfile(k):
-                with open(k, "rb") as file:
+        for src_path, dest_path in archive_files.items():
+            path = f"{config['name']}.app/Contents/Resources/{dest_path}"
+            if os.path.isfile(src_path):
+                with open(src_path, "rb") as file:
                     app_zip.writestr(path, file.read())
-            elif os.path.isdir(k):
-                directory = Path(k)
+            elif os.path.isdir(src_path):
+                directory = Path(src_path)
                 for file_path in directory.glob("**/*"):
                     if not file_path.is_file():
                         continue
                     with open(file_path, "rb") as file:
-                        relative = file_path.relative_to(k)
-                        path = f"{config['name']}.app/Contents/Resources/{v}/{relative}"
+                        relative = file_path.relative_to(src_path)
+                        path = f"{config['name']}.app/Contents/Resources/{dest_path}/{relative}"
                         app_zip.writestr(path, file.read())
                         written_files.add(path)
             else:
-                sys.exit(f"Cannot copy archive file '{k}'")
+                sys.exit(f"Cannot copy archive file '{src_path}'")
             written_files.add(path)
 
         for zipinfo in love_binary_zip.infolist():

--- a/makelove/macos.py
+++ b/makelove/macos.py
@@ -217,7 +217,7 @@ def build_macos(config, version, target, target_directory, love_file_path):
             zipinfo.date_time = tuple(datetime.now().timetuple()[:6])
 
             if zipinfo.filename in written_files:
-                continue  # avoid duplicates
+                continue  # don't make a duplicate of a file already inserted by archive_files
             elif orig_filename == "love.app/Contents/Resources/GameIcon.icns":
                 continue  # not needed for game distributions
             elif orig_filename == "love.app/Contents/Resources/Assets.car":

--- a/makelove_full.toml
+++ b/makelove_full.toml
@@ -48,7 +48,7 @@ icon_file = "icon.png"
 # the temporary game directory will be deleted, unless this parameter is true
 keep_game_directory = false
 
-# This specifies the files to be included in the zip archives generated for windows builds.
+# This specifies the files to be included in the zip archives generated for windows and macos builds.
 # The key is the relative (to the game directory) source path
 # and the value is the destination path relative to the archive root.
 # You may specify files or directories
@@ -114,6 +114,9 @@ artifacts = "archive"
 # The values above for the target win32 can also be set for the win64 target
 
 [macos]
+# This is the same as archive_files at the top level, but will be added to the archive additionally
+[macos.archive_files]
+
 # optionally, you can include a mac-specific icon, if not mac will use the same icon as other targets
 icon_file = "macIcon.png"  # or macIcon.icns
 

--- a/makelove_full.toml
+++ b/makelove_full.toml
@@ -115,6 +115,7 @@ artifacts = "archive"
 
 [macos]
 # This is the same as archive_files at the top level, but will be added to the archive additionally
+# (these files will be added in <name>/Contents/Resources/)
 [macos.archive_files]
 
 # optionally, you can include a mac-specific icon, if not mac will use the same icon as other targets


### PR DESCRIPTION
This PR adds `macos.archive_files`, which works the same way as `windows.archive_files`, but for MacOS instead.
Files are stored in `<name>/Contents/Resources/`.
This PR has been tested with single files and directories (that included files and more directories inside).
Additionally, `archive_files` is now used for MacOS too, not only Windows.