### PR TITLE
Add win32/win64 option to precompile bytecode

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A packaging tool for [löve](https://love2d.org) games
 * Proper handling of shared libraries (both Lua modules and FFI)!
 * Packaging of those binaries in archives, including extra files
 * Versioned builds
+* Precompile lua scripts to bytecode (win32 and win64 and only on Windows)
 * Control and customization along the way:
     - Configure which targets to build
     - Which files to include in the .love with a list of include/exclude patterns

--- a/how_to_x.md
+++ b/how_to_x.md
@@ -35,3 +35,12 @@ And finally build without prebuild, but with postbuild
 ```
 makelove -d prebuild -v 1.2.3 appimage (--resume)
 ```
+
+## Compile lua scripts to bytecode
+Use the option `compile_lua = true` in `makelove.toml` in the `win32` or `win64` sections.
+The created .exe will now contain bytecode instead of scripts.
+
+To check if a script is compiled as bytecode, you can add this code to your game:
+```lua
+is_compiled = (love.filesystem.read('main.lua', 1) == '\x1b' and true or false)
+```

--- a/makelove/bytecode.py
+++ b/makelove/bytecode.py
@@ -1,0 +1,31 @@
+import os
+import subprocess
+import zipfile
+import base64
+
+def compile_file(love_binary, data, filename):
+    # Compile a single .lua file to bytecode using love.
+    # To support this, we have a folder 'love-luac' that will be recognized as 'game' by love
+    compiler = os.path.join(os.path.dirname(__file__), 'love-luac')
+    compile_args = [love_binary, compiler]
+    proc = subprocess.Popen(compile_args, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+    # (Binary) data is base64 encoded to work around the fact that lua opens stdin/stdout in text mode on windows,
+    # which would break the bytecode
+    out = proc.communicate(input=base64.b64encode(data))
+    if proc.returncode == 0:
+        return base64.b64decode(out[0])
+    print('Failed to compile {}: {}'.format(filename, out[0]))
+    return data
+
+
+def create_compiled_lovezip(love_binary, love_file_path_in, love_file_path_out):
+    # Create a new zip with all .lua files converted to bytecode
+    with zipfile.ZipFile(love_file_path_in, 'r') as zip_in:
+        with zipfile.ZipFile(love_file_path_out, 'w') as zip_out:
+            zip_out.comment = zip_in.comment # preserve the comment
+            for item in zip_in.infolist():
+                data = zip_in.read(item.filename)
+                if item.filename.endswith('.lua'):
+                    data = compile_file(love_binary, data, item.filename)
+                zip_out.writestr(item, data)
+

--- a/makelove/config.py
+++ b/makelove/config.py
@@ -70,6 +70,7 @@ config_params = {
             "love_binaries": val.Path(),
             "shared_libraries": val.List(val.Path()),
             "artifacts": val.ValueOrList(val.Choice("directory", "archive")),
+            "compile_lua": val.Bool(),
         }
     ),
     "win64": val.Section(
@@ -77,6 +78,7 @@ config_params = {
             "love_binaries": val.Path(),
             "shared_libraries": val.List(val.Path()),
             "artifacts": val.ValueOrList(val.Choice("directory", "archive")),
+            "compile_lua": val.Bool(),
         }
     ),
     "linux": val.Section(

--- a/makelove/love-luac/conf.lua
+++ b/makelove/love-luac/conf.lua
@@ -1,0 +1,5 @@
+-- love configuration handler to suppress the window popping up.
+
+function love.conf(t)
+    t.window = nil
+end

--- a/makelove/love-luac/main.lua
+++ b/makelove/love-luac/main.lua
@@ -1,0 +1,26 @@
+--[[
+    Handler used to convert lua code to bytecode.
+    This is setup as a 'game', so that the love binary that we are appending to can run this.
+]]
+
+function love.load()
+    -- Read input from stdin
+    -- This is base64 encoded to ensure no translation occurs on windows
+    local source = love.data.decode("string", "base64", io.read())
+    -- Load the data
+    local lua_data = assert(load(source))
+    -- Convert to bytecode, strip debug symbols
+    local stripped = assert(string.dump(lua_data, true))
+    -- Encode the bytecode to base64 again
+    local encoded = love.data.encode('string', 'base64', stripped, 0)
+    -- Send it back
+    io.write(encoded)
+    -- Great success
+    os.exit(0, true)
+end
+
+function love.errorhandler(msg)
+    msg = tostring(msg)
+    print(msg)
+    os.exit(1, true)
+end

--- a/makelove_full.toml
+++ b/makelove_full.toml
@@ -114,6 +114,11 @@ shared_libraries = [
 # after the .zip has been built.
 artifacts = "archive"
 
+# Whether or not to compile lua code to bytecode.
+# If this option is set to true, the build needs to run on windows, because love.exe for windows
+# is used to compile the lua files.
+compile_lua = false
+
 # The values above for the target win32 can also be set for the win64 target
 
 [macos]


### PR DESCRIPTION
Initial PR with a working sample.

* love.exe is used to compile the files, so that the bytecode format is correct
* Each build needs it's own .zip file, they are created on demand, and deleted after
* Only Windows is implemented for now, but it should not be too hard to also include Linux

- [x] Tested locally on Windows (without installing makelove, running it straight from the repo)
- [ ] Implement for Linux?
- [ ] Test with a pip-installed `makelove`
- [ ] ??